### PR TITLE
Friendly compilation errors

### DIFF
--- a/run
+++ b/run
@@ -52,14 +52,27 @@ pretty_compilation_errors() {
     # fi
 }
 
+# Compilation parsing
+compilation_error_count() {
+    echo "$1" | egrep -o "[0-9]+ error$" | sed "s/[^0-9]//g"
+}
+
 # Compilation json
 compilation_error_in_submission() {
-    compile_err=$(pretty_compilation_errors $1)
+    compile_err=$(cat $1)
+    compile_err_count=$(compilation_error_count "$compile_err")
+
+    if [[ "$compile_err_count" -eq "1" ]]; then
+        compile_err_word="fout"
+    else
+        compile_err_word="fouten"
+    fi
+
 
     jshon -Q -n object                                             \
         -n false -i 'accepted'                                     \
         -s 'compilation error' -i 'status'                         \
-        -s "in jouw code" -i 'description'                         \
+        -s "$compile_err_count $compile_err_word" -i 'description' \
         -n array                                                   \
             -n object                                              \
                 -s 'Compiler' -i 'description'                     \

--- a/run
+++ b/run
@@ -34,14 +34,18 @@ memory_limit="$(( memory_limit * 9 / 10000 ))"
 start_time="$(date +"%s")"
 
 # User friendly compilation errors
-pretty_compilation_error() {
+pretty_compilation_errors() {
     compile_err=$(cat $1)
+
+    # Get the amount of compilation errors.
+    amount_of_errors=$(echo $compile_err | egrep -o "[0-9]+ errors$" | sed "s/[^0-9]//g")
+    echo -e "$amount_of_errors fouten traden op tijdens het compileren van je ingediende oplossing.\n"
 
     # Test the name of the class.
     wrong_class=$(echo $compile_err | grep -c "should be declared in a file named")
     if [ "$wrong_class" -eq "1" ]; then
-        correct_class_name=$(echo $compile_err | grep -o "^\w*.java" | sed "s/.java//g")
-        student_class_name=$(echo $compile_err | grep -o "public class \w*" | sed "s/public class //g")
+        correct_class_name=$(echo $compile_err | egrep -o "^\w+.java" | sed "s/.java//g")
+        student_class_name=$(echo $compile_err | egrep -o "public class \w+" | sed "s/public class //g")
         echo "De ingediende klasse heeft een foute naam. De klasse hoort als naam \"$correct_class_name\" te hebben, jouw klasse heeft als naam \"$student_class_name\"."
     else
         echo "$compile_err"
@@ -50,7 +54,7 @@ pretty_compilation_error() {
 
 # Compilation json
 compilation_error() {
-    compile_err=$(pretty_compilation_error $2)
+    compile_err=$(pretty_compilation_errors $2)
 
     jshon -Q -n object                                             \
         -n false -i 'accepted'                                     \

--- a/run
+++ b/run
@@ -41,25 +41,25 @@ pretty_compilation_errors() {
     amount_of_errors=$(echo $compile_err | egrep -o "[0-9]+ errors$" | sed "s/[^0-9]//g")
     echo -e "$amount_of_errors fouten traden op tijdens het compileren van je ingediende oplossing.\n"
 
-    # Test the name of the class.
-    wrong_class=$(echo $compile_err | grep -c "should be declared in a file named")
-    if [ "$wrong_class" -eq "1" ]; then
-        correct_class_name=$(echo $compile_err | egrep -o "^\w+.java" | sed "s/.java//g")
-        student_class_name=$(echo $compile_err | egrep -o "public class \w+" | sed "s/public class //g")
-        echo "De ingediende klasse heeft een foute naam. De klasse hoort als naam \"$correct_class_name\" te hebben, jouw klasse heeft als naam \"$student_class_name\"."
-    else
-        echo "$compile_err"
-    fi
+    # # Test the name of the class.
+    # wrong_class=$(echo $compile_err | grep -c "should be declared in a file named")
+    # if [ "$wrong_class" -eq "1" ]; then
+    #     correct_class_name=$(echo $compile_err | egrep -o "^\w+.java" | sed "s/.java//g")
+    #     student_class_name=$(echo $compile_err | egrep -o "public class \w+" | sed "s/public class //g")
+    #     echo "De ingediende klasse heeft een foute naam. De klasse hoort als naam \"$correct_class_name\" te hebben, jouw klasse heeft als naam \"$student_class_name\"."
+    # else
+    #     echo "$compile_err"
+    # fi
 }
 
 # Compilation json
-compilation_error() {
-    compile_err=$(pretty_compilation_errors $2)
+compilation_error_in_submission() {
+    compile_err=$(pretty_compilation_errors $1)
 
     jshon -Q -n object                                             \
         -n false -i 'accepted'                                     \
         -s 'compilation error' -i 'status'                         \
-        -s "$1" -i 'description'                                   \
+        -s "in jouw code" -i 'description'                         \
         -n array                                                   \
             -n object                                              \
                 -s 'Compiler' -i 'description'                     \
@@ -70,6 +70,36 @@ compilation_error() {
                             -n object                              \
                                 -s 'code' -i 'format'              \
                                 -s "$compile_err" -i 'description' \
+                            -i 0                                   \
+                        -i 'messages'                              \
+                    -i 0                                           \
+                -i 'groups'                                        \
+            -i 0                                                   \
+        -i 'groups'
+}
+
+compilation_error_in_tests() {
+    compile_err=$(cat $1)
+    description="De tests van deze opgave bevatten een fout, contacteer de lesgever."
+
+    jshon -Q -n object                                             \
+        -n false -i 'accepted'                                     \
+        -s 'compilation error' -i 'status'                         \
+        -s "in tests" -i 'description'                             \
+        -n array                                                   \
+            -n object                                              \
+                -s 'Compiler' -i 'description'                     \
+                -n array                                           \
+                    -n object                                      \
+                        -n false -i 'accepted'                     \
+                        -n array                                   \
+                            -n object                              \
+                                -s 'code' -i 'format'              \
+                                -s "$compile_err" -i 'description' \
+                            -i 0                                   \
+                            -n object                              \
+                                -s 'plain' -i 'format'             \
+                                -s "$description" -i 'description' \
                             -i 0                                   \
                         -i 'messages'                              \
                     -i 0                                           \
@@ -102,7 +132,7 @@ debug compiled judge
 
 # Compiling the workdir given code
 if ! find . -name '*.java' | xargs --no-run-if-empty javac -cp ".:${worklibs}:${testlibs}" -d . -sourcepath . > "$compilation" 2>&1; then
-    compilation_error "in workdir" <(sed 's_.*/\([^/]*.java\)_\1_' "$compilation")
+    compilation_error_in_tests <(sed 's_.*/\([^/]*.java\)_\1_' "$compilation")
     exit 0
 fi
 
@@ -113,7 +143,7 @@ cat "$(jshon -e 'source' -u < "$config")" > "$filename"
 
 # Compiling the user code
 if ! javac -cp ".:${worklibs}" -Xlint:all "$filename" > "$compilation" 2>&1; then
-    compilation_error "in submitted code" "$compilation" \
+    compilation_error_in_submission "$compilation" \
     | if grep -q '^package' "$filename"; then
         add_compilation_description "Are you sure the submitted class is in the default package?"
       else
@@ -126,7 +156,7 @@ debug compiled user code
 
 # Compiling the tests
 if ! find "$resources" -name '*.java' | xargs javac -cp ".:${resources}:${worklibs}:${testlibs}:judge.jar" -d . -sourcepath "$resources" > "$compilation" 2>&1; then
-    compilation_error "in tests" <(sed 's_.*/\([^/]*.java\)_\1_' "$compilation")
+    compilation_error_in_tests <(sed 's_.*/\([^/]*.java\)_\1_' "$compilation")
     exit 0
 fi
 

--- a/run
+++ b/run
@@ -97,7 +97,7 @@ compilation_error_in_submission() {
                         -n array                                          \
                             -n object                                     \
                                 -s 'code' -i 'format'                     \
-                                -s "$compile_err" -i 'description'        \
+                                -s "$compile_err" -i 'description'        \ahar
                             -i 0                                          \
                             -n object                                     \
                                 -s 'code' -i 'format'                     \
@@ -116,27 +116,27 @@ compilation_error_in_submission() {
 
 compilation_error_in_tests() {
     compile_err=$(cat $1)
-    description="De tests van deze opgave bevatten een fout, contacteer de lesgever."
+    description="De testen van deze opgave bevatten een fout, contacteer de lesgever."
 
     jshon -Q -n object                                             \
         -n false -i 'accepted'                                     \
         -s 'compilation error' -i 'status'                         \
-        -s "in tests" -i 'description'                             \
+        -s "in testen" -i 'description'                            \
         -n array                                                   \
             -n object                                              \
                 -s 'Compiler' -i 'description'                     \
                 -n array                                           \
                     -n object                                      \
                         -n false -i 'accepted'                     \
+                        -n object                                  \
+                            -s 'plain' -i 'format'                 \
+                            -s "$description" -i 'description'     \
+                        -i 'description'                           \
                         -n array                                   \
                             -n object                              \
                                 -s 'code' -i 'format'              \
                                 -s 'staff' -i 'permission'         \
                                 -s "$compile_err" -i 'description' \
-                            -i 0                                   \
-                            -n object                              \
-                                -s 'plain' -i 'format'             \
-                                -s "$description" -i 'description' \
                             -i 0                                   \
                         -i 'messages'                              \
                     -i 0                                           \

--- a/run
+++ b/run
@@ -39,7 +39,7 @@ pretty_compilation_error() {
 
     # Test the name of the class.
     wrong_class=$(echo $compile_err | grep -c "should be declared in a file named")
-    if [ "$wrong_class" -eq "1" ];
+    if [ "$wrong_class" -eq "1" ]; then
         correct_class_name=$(echo $compile_err | grep -o "^\w*.java" | sed "s/.java//g")
         student_class_name=$(echo $compile_err | grep -o "public class \w*" | sed "s/public class //g")
         echo "De ingediende klasse heeft een foute naam. De klasse hoort als naam \"$correct_class_name\" te hebben, jouw klasse heeft als naam \"$student_class_name\"."

--- a/run
+++ b/run
@@ -94,18 +94,18 @@ compilation_error_in_submission() {
                 -n array                                                  \
                     -n object                                             \
                         -n false -i 'accepted'                            \
+                        -n object                                         \
+                            -s 'plain' -i 'format'                        \
+                            -s "$compile_msg" -i 'description'            \
+                        -i 'description'                                  \
                         -n array                                          \
                             -n object                                     \
                                 -s 'code' -i 'format'                     \
-                                -s "$compile_err" -i 'description'        \ahar
+                                -s "$compile_err" -i 'description'        \
                             -i 0                                          \
                             -n object                                     \
                                 -s 'code' -i 'format'                     \
                                 -s "$compile_err_pretty" -i 'description' \
-                            -i 0                                          \
-                            -n object                                     \
-                                -s 'plain' -i 'format'                    \
-                                -s "$compile_msg" -i 'description'        \
                             -i 0                                          \
                         -i 'messages'                                     \
                     -i 0                                                  \

--- a/run
+++ b/run
@@ -35,45 +35,48 @@ start_time="$(date +"%s")"
 
 # User friendly compilation errors
 pretty_compilation_errors() {
-    compile_err=$(cat $1)
-
-    # Get the amount of compilation errors.
-    amount_of_errors=$(echo $compile_err | egrep -o "[0-9]+ errors$" | sed "s/[^0-9]//g")
-    echo -e "$amount_of_errors fouten traden op tijdens het compileren van je ingediende oplossing.\n"
-
-    # # Test the name of the class.
-    # wrong_class=$(echo $compile_err | grep -c "should be declared in a file named")
-    # if [ "$wrong_class" -eq "1" ]; then
-    #     correct_class_name=$(echo $compile_err | egrep -o "^\w+.java" | sed "s/.java//g")
-    #     student_class_name=$(echo $compile_err | egrep -o "public class \w+" | sed "s/public class //g")
-    #     echo "De ingediende klasse heeft een foute naam. De klasse hoort als naam \"$correct_class_name\" te hebben, jouw klasse heeft als naam \"$student_class_name\"."
-    # else
-    #     echo "$compile_err"
-    # fi
+    # Test the name of the class.
+    wrong_class=$(echo $compile_err | grep -c "should be declared in a file named")
+    if [ "$wrong_class" -eq "1" ]; then
+        expect_class_name=$(echo $compile_err | egrep -o "^\w+.java" | sed "s/.java//g")
+        student_class_name=$(echo $compile_err | egrep -o "public class \w+" | sed "s/public class //g")
+        echo "De ingediende klasse heeft een foute naam. De klasse hoort als naam \"$expect_class_name\" te hebben, jouw klasse heeft als naam \"$student_class_name\"."
+    fi
 }
 
 # Compilation parsing
 compilation_error_count() {
-    echo "$1" | egrep -o "[0-9]+ error$" | sed "s/[^0-9]//g"
+    echo "$1" | egrep -o "[0-9]+ errors?$" | sed "s/[^0-9]//g"
 }
 
 compilation_warning_count() {
-    echo "$1" | egrep -o "[0-9]+ warning$" | sed "s/[^0-9]//g"
+    echo "$1" | egrep -o "[0-9]+ warnings?$" | sed "s/[^0-9]//g"
 }
 
 # Compilation json
 compilation_error_in_submission() {
     compile_err=$(cat $1)
+
+    # Get the amount of errors/warnings as a number.
     compile_err_count=$(compilation_error_count "$compile_err")
     compile_warn_count=$(compilation_warning_count "$compile_err")
 
-    if [[ "$compile_err_count" -eq "1" ]]; then
+    # Get the pretty feedback.
+    # TODO: Maybe create a new message for every parsed item instead of simply
+    # TODO: concatenating everything in 1 message.
+    compile_err_pretty=$(pretty_compilation_errors "$compile_err")
+
+    # Strip the amount of errors/warnings since we're already displaying that
+    # somewhere else.
+    compile_err=$(echo "$compile_err" | sed "s/[0-9]\+ \(error\|warning\)s\?$//g")
+
+    if [ "$compile_err_count" -eq "1" ]; then
         compile_err_word="fout"
     else
         compile_err_word="fouten"
     fi
 
-    if [[ "$compile_warn_count" -eq "1" ]]; then
+    if [ "$compile_warn_count" -eq "1" ]; then
         compile_warn_word="waarschuwing"
     else
         compile_warn_word="waarschuwingen"
@@ -81,29 +84,33 @@ compilation_error_in_submission() {
 
     compile_msg="Je oplossing kon niet worden gecompileerd, de compiler rapporteerde $compile_err_count $compile_err_word en $compile_warn_count $compile_warn_word:"
 
-    jshon -Q -n object                                             \
-        -n false -i 'accepted'                                     \
-        -s 'compilation error' -i 'status'                         \
-        -s "$compile_err_count $compile_err_word" -i 'description' \
-        -n array                                                   \
-            -n object                                              \
-                -s 'Compiler' -i 'description'                     \
-                -n array                                           \
-                    -n object                                      \
-                        -n false -i 'accepted'                     \
-                        -n array                                   \
-                            -n object                              \
-                                -s 'code' -i 'format'              \
-                                -s "$compile_err" -i 'description' \
-                            -i 0                                   \
-                            -n object                              \
-                                -s 'plain' -i 'format'             \
-                                -s "$compile_msg" -i 'description' \
-                            -i 0                                   \
-                        -i 'messages'                              \
-                    -i 0                                           \
-                -i 'groups'                                        \
-            -i 0                                                   \
+    jshon -Q -n object                                                    \
+        -n false -i 'accepted'                                            \
+        -s 'compilation error' -i 'status'                                \
+        -s "$compile_err_count $compile_err_word" -i 'description'        \
+        -n array                                                          \
+            -n object                                                     \
+                -s 'Compiler' -i 'description'                            \
+                -n array                                                  \
+                    -n object                                             \
+                        -n false -i 'accepted'                            \
+                        -n array                                          \
+                            -n object                                     \
+                                -s 'code' -i 'format'                     \
+                                -s "$compile_err" -i 'description'        \
+                            -i 0                                          \
+                            -n object                                     \
+                                -s 'code' -i 'format'                     \
+                                -s "$compile_err_pretty" -i 'description' \
+                            -i 0                                          \
+                            -n object                                     \
+                                -s 'plain' -i 'format'                    \
+                                -s "$compile_msg" -i 'description'        \
+                            -i 0                                          \
+                        -i 'messages'                                     \
+                    -i 0                                                  \
+                -i 'groups'                                               \
+            -i 0                                                          \
         -i 'groups'
 }
 

--- a/run
+++ b/run
@@ -57,10 +57,15 @@ compilation_error_count() {
     echo "$1" | egrep -o "[0-9]+ error$" | sed "s/[^0-9]//g"
 }
 
+compilation_warning_count() {
+    echo "$1" | egrep -o "[0-9]+ warning$" | sed "s/[^0-9]//g"
+}
+
 # Compilation json
 compilation_error_in_submission() {
     compile_err=$(cat $1)
     compile_err_count=$(compilation_error_count "$compile_err")
+    compile_warn_count=$(compilation_warning_count "$compile_err")
 
     if [[ "$compile_err_count" -eq "1" ]]; then
         compile_err_word="fout"
@@ -68,6 +73,13 @@ compilation_error_in_submission() {
         compile_err_word="fouten"
     fi
 
+    if [[ "$compile_warn_count" -eq "1" ]]; then
+        compile_warn_word="waarschuwing"
+    else
+        compile_warn_word="waarschuwingen"
+    fi
+
+    compile_msg="Je oplossing kon niet worden gecompileerd, de compiler rapporteerde $compile_err_count $compile_err_word en $compile_warn_count $compile_warn_word:"
 
     jshon -Q -n object                                             \
         -n false -i 'accepted'                                     \
@@ -83,6 +95,10 @@ compilation_error_in_submission() {
                             -n object                              \
                                 -s 'code' -i 'format'              \
                                 -s "$compile_err" -i 'description' \
+                            -i 0                                   \
+                            -n object                              \
+                                -s 'plain' -i 'format'             \
+                                -s "$compile_msg" -i 'description' \
                             -i 0                                   \
                         -i 'messages'                              \
                     -i 0                                           \

--- a/run
+++ b/run
@@ -33,27 +33,44 @@ memory_limit="$(( memory_limit * 9 / 10000 ))"
 # Record time
 start_time="$(date +"%s")"
 
+# User friendly compilation errors
+pretty_compilation_error() {
+    compile_err=$(cat $1)
+
+    # Test the name of the class.
+    wrong_class=$(echo $compile_err | grep -c "should be declared in a file named")
+    if [ "$wrong_class" -eq "1" ]; then
+      correct_class_name=$(echo $compile_err | grep -o "^\w*.java" | sed "s/.java//g")
+      student_class_name=$(echo $compile_err | grep -o "public class \w*" | sed "s/public class //g")
+      echo "De ingediende klasse heeft een foute naam. De klasse hoort als naam \"$correct_class_name\" te hebben, jouw klasse heeft als naam \"$student_class_name\"."
+    else
+      echo "$compile_err"
+    fi
+}
+
 # Compilation json
 compilation_error() {
-    jshon -Q -n object                                          \
-        -n false -i 'accepted'                                  \
-        -s 'compilation error' -i 'status'                      \
-        -s "$1" -i 'description'                                \
-        -n array                                                \
-            -n object                                           \
-                -s 'Compiler' -i 'description'                  \
-                -n array                                        \
-                    -n object                                   \
-                        -n false -i 'accepted'                  \
-                        -n array                                \
-                            -n object                           \
-                                -s 'code' -i 'format'           \
-                                -s "$(cat $2)" -i 'description' \
-                            -i 0                                \
-                        -i 'messages'                           \
-                    -i 0                                        \
-                -i 'groups'                                     \
-            -i 0                                                \
+    compile_err=$(pretty_compilation_error $2)
+
+    jshon -Q -n object                                             \
+        -n false -i 'accepted'                                     \
+        -s 'compilation error' -i 'status'                         \
+        -s "$1" -i 'description'                                   \
+        -n array                                                   \
+            -n object                                              \
+                -s 'Compiler' -i 'description'                     \
+                -n array                                           \
+                    -n object                                      \
+                        -n false -i 'accepted'                     \
+                        -n array                                   \
+                            -n object                              \
+                                -s 'code' -i 'format'              \
+                                -s "$compile_err" -i 'description' \
+                            -i 0                                   \
+                        -i 'messages'                              \
+                    -i 0                                           \
+                -i 'groups'                                        \
+            -i 0                                                   \
         -i 'groups'
 }
 

--- a/run
+++ b/run
@@ -39,12 +39,12 @@ pretty_compilation_error() {
 
     # Test the name of the class.
     wrong_class=$(echo $compile_err | grep -c "should be declared in a file named")
-    if [ "$wrong_class" -eq "1" ]; then
-      correct_class_name=$(echo $compile_err | grep -o "^\w*.java" | sed "s/.java//g")
-      student_class_name=$(echo $compile_err | grep -o "public class \w*" | sed "s/public class //g")
-      echo "De ingediende klasse heeft een foute naam. De klasse hoort als naam \"$correct_class_name\" te hebben, jouw klasse heeft als naam \"$student_class_name\"."
+    if [ "$wrong_class" -eq "1" ];
+        correct_class_name=$(echo $compile_err | grep -o "^\w*.java" | sed "s/.java//g")
+        student_class_name=$(echo $compile_err | grep -o "public class \w*" | sed "s/public class //g")
+        echo "De ingediende klasse heeft een foute naam. De klasse hoort als naam \"$correct_class_name\" te hebben, jouw klasse heeft als naam \"$student_class_name\"."
     else
-      echo "$compile_err"
+        echo "$compile_err"
     fi
 }
 

--- a/run
+++ b/run
@@ -131,6 +131,7 @@ compilation_error_in_tests() {
                         -n array                                   \
                             -n object                              \
                                 -s 'code' -i 'format'              \
+                                -s 'staff' -i 'permission'         \
                                 -s "$compile_err" -i 'description' \
                             -i 0                                   \
                             -n object                              \


### PR DESCRIPTION
When the submitted code has an incorrect name, a custom message is displayed instead of the usual Java compiler output. This can be useful for students from other courses that have never seen a compiler and are clueless about what their mistake is.

More messages could be added along the way, maybe this behaviour could be toggled on/off using the `config.json` file in the exercise, similar to the running time/memory usage limits.

_[Original pull request](https://github.ugent.be/dodona/judge-java/pull/13) by @thepieterdc on Sun Apr 07 2019 at 21:41._
_Merged by @thepieterdc on Wed Apr 10 2019 at 01:01._