### PR TITLE
tests -> testen; mislukt -> gefaald

### DIFF
--- a/src/dodona/feedback/Feedback.java
+++ b/src/dodona/feedback/Feedback.java
@@ -31,7 +31,7 @@ public class Feedback extends Group<Tab> {
                 this.description = (executed - failed) + " " + pluralize(executed - failed, "test", "testen") + " geslaagd";
                 break;
             default:
-                this.description = failed + " " + pluralize(failed, "test", "testen") + " mislukt";
+                this.description = failed + " " + pluralize(failed, "test", "testen") + " gefaald";
 
                 break;
         }

--- a/src/dodona/feedback/Feedback.java
+++ b/src/dodona/feedback/Feedback.java
@@ -25,13 +25,13 @@ public class Feedback extends Group<Tab> {
         long executed = children().mapToLong(t -> t.children().count()).sum();
         switch(status) {
             case TIME_LIMIT_EXCEEDED:
-                this.description = executed + " " + pluralize(executed, "test", "tests") + " uitgevoerd";
+                this.description = executed + " " + pluralize(executed, "test", "testen") + " uitgevoerd";
                 break;
             case CORRECT:
-                this.description = (executed - failed) + " " + pluralize(executed - failed, "test", "tests") + " geslaagd";
+                this.description = (executed - failed) + " " + pluralize(executed - failed, "test", "testen") + " geslaagd";
                 break;
             default:
-                this.description = failed + " " + pluralize(failed, "test", "tests") + " mislukt";
+                this.description = failed + " " + pluralize(failed, "test", "testen") + " mislukt";
 
                 break;
         }


### PR DESCRIPTION
Zowel tests als testen zijn correct Nederlands, maar op andere plaatsen op Dodona gebruiken we testen.

Gefaald vs mislukt -> gefaald

_[Original pull request](https://github.ugent.be/dodona/judge-java/pull/14) by @bmesuere on Mon Apr 08 2019 at 21:57._
_Merged by @ninewise on Tue Apr 09 2019 at 13:28._