### PR TITLE
Partial output & Compilation error hints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 .idea/
 build/
 dist/
+testing/*.class
+testing/*.jar
+testing/*.java

--- a/dodona-json
+++ b/dodona-json
@@ -1,0 +1,109 @@
+#!/bin/bash
+
+###################### [ Partial output helper functions ] #####################
+
+### [ Contexts ]
+dodona_close_failed_context() {
+    jshon -Q -n object                  \
+        -s 'close-context' -i 'command' \
+        -n 'false' -i 'accepted'
+}
+
+dodona_close_context() {
+    jshon -Q -n object -s 'close-context' -i 'command'
+}
+
+dodona_start_context() {
+    jshon -n object -s 'start-context' -i 'command'
+}
+
+### [ Judgement ]
+dodona_close_judgement_compilation_error() {
+    # arg1: description
+
+    jshon -Q -n object                       \
+        -s 'close-judgement' -i 'command'    \
+        -n 'false' -i 'accepted'             \
+        -n object                            \
+            -s 'compilation error' -i 'enum' \
+            -s "$1" -i 'human'               \
+        -i 'status'
+}
+
+dodona_close_judgement() {
+    jshon -Q -n object -s 'close-judgement' -i 'command'
+}
+
+dodona_start_judgement() {
+    jshon -Q -n object -s 'start-judgement' -i 'command'
+}
+
+### [ Messages ]
+dodona_append_plain_message() {
+    # arg1: message contents
+    dodona_append_message 'plain' 'student' "$1"
+}
+
+dodona_append_message() {
+    # arg1: format
+    # arg2: permission
+    # arg3: message contents
+
+    jshon -Q -n object                   \
+        -s 'append-message' -i 'command' \
+        -n object                        \
+            -s "$1" -i 'format'          \
+            -s "$2" -i 'permission'      \
+            -s "$3" -i 'description'     \
+        -i 'message'
+}
+
+### [ Tabs ]
+dodona_close_tab() {
+    # arg1: badge count (optional: default 0)
+    [[ "$1" == "" ]] && badge_count=0 || badge_count="$1"
+
+    jshon -Q -n object                    \
+        -s 'close-tab' -i 'command'       \
+        -n $badge_count -i 'badgeCount'
+}
+
+dodona_start_hidden_tab() {
+    # arg1: title
+    jshon -Q -n object              \
+        -s 'start-tab' -i 'command' \
+        -n 'true' -i 'hidden'       \
+        -s "$1" -i 'title'
+}
+
+dodona_start_tab() {
+    # arg1: title
+    jshon -Q -n object              \
+        -s 'start-tab' -i 'command' \
+        -n 'false' -i 'hidden'      \
+        -s "$1" -i 'title'
+}
+
+### [Testcases]
+dodona_close_failed_testcase() {
+    jshon -Q -n object                   \
+        -s 'close-testcase' -i 'command' \
+        -n 'false' -i 'accepted'
+}
+
+dodona_close_testcase() {
+    jshon -Q -n object -s 'close-testcase' -i 'command'
+}
+
+dodona_start_testcase_code_message() {
+    # arg1: description
+    description=$(echo -e "$1")
+
+    jshon -Q -n object                         \
+        -s 'start-testcase' -i 'command'       \
+        -n object                              \
+            -s 'code' -i 'format'              \
+            -s 'student' -i 'permission'       \
+            -s "$description" -i 'description' \
+        -i 'description'
+}

--- a/dodona-json
+++ b/dodona-json
@@ -1,22 +1,8 @@
-#!/bin/bash
+#!/bin/sh
 
 ###################### [ Partial output helper functions ] #####################
 
 ### [ Annotations ]
-dodona_annotate_code_error() {
-    # arg1: row
-    # arg2: column
-    # arg3: annotation text
-    dodona_annotate_code 'error' "$1" "$2" "$3"
-}
-
-dodona_annotate_code_warning() {
-    # arg1: row
-    # arg2: column
-    # arg3: annotation text
-    dodona_annotate_code 'warning' "$1" "$2" "$3"
-}
-
 dodona_annotate_code() {
     # arg1: type
     # arg2: row
@@ -67,6 +53,26 @@ dodona_start_judgement() {
 }
 
 ### [ Messages ]
+dodona_append_code_message_staff() {
+    # arg1: message contents
+    dodona_append_message 'code' 'staff' "$1"
+}
+
+dodona_append_code_message() {
+    # arg1: message contents
+    dodona_append_message 'code' 'student' "$1"
+}
+
+dodona_append_html_message() {
+    # arg1: message contents
+    dodona_append_message 'html' 'student' "$1"
+}
+
+dodona_append_markdown_message() {
+    # arg1: message contents
+    dodona_append_message 'markdown' 'student' "$1"
+}
+
 dodona_append_plain_message() {
     # arg1: message contents
     dodona_append_message 'plain' 'student' "$1"
@@ -89,7 +95,7 @@ dodona_append_message() {
 ### [ Tabs ]
 dodona_close_tab() {
     # arg1: badge count (optional: default 0)
-    [[ "$1" == "" ]] && badge_count=0 || badge_count="$1"
+    badge_count="${1:-0}"
 
     jshon -Q -n object                    \
         -s 'close-tab' -i 'command'       \
@@ -123,15 +129,14 @@ dodona_close_testcase() {
     jshon -Q -n object -s 'close-testcase' -i 'command'
 }
 
-dodona_start_testcase_code_message() {
+dodona_start_testcase_markdown_message() {
     # arg1: description
-    description=$(echo -e "$1")
 
-    jshon -Q -n object                         \
-        -s 'start-testcase' -i 'command'       \
-        -n object                              \
-            -s 'code' -i 'format'              \
-            -s 'student' -i 'permission'       \
-            -s "$description" -i 'description' \
+    jshon -Q -n object                   \
+        -s 'start-testcase' -i 'command' \
+        -n object                        \
+            -s 'markdown' -i 'format'    \
+            -s 'student' -i 'permission' \
+            -s "$1" -i 'description'     \
         -i 'description'
 }

--- a/dodona-json
+++ b/dodona-json
@@ -2,6 +2,34 @@
 
 ###################### [ Partial output helper functions ] #####################
 
+### [ Annotations ]
+dodona_annotate_code_error() {
+    # arg1: row
+    # arg2: column
+    # arg3: annotation text
+    dodona_annotate_code 'error' "$1" "$2" "$3"
+}
+
+dodona_annotate_code_warning() {
+    # arg1: row
+    # arg2: column
+    # arg3: annotation text
+    dodona_annotate_code 'warning' "$1" "$2" "$3"
+}
+
+dodona_annotate_code() {
+    # arg1: type
+    # arg2: row
+    # arg3: column
+    # arg4: annotation text
+    jshon -Q -n object                \
+        -s 'annotate-code' -i command \
+        -n "$3" -i 'column'           \
+        -n "$2" -i 'row'              \
+        -s "$1" -i 'type'             \
+        -s "$4" -i 'text'
+}
+
 ### [ Contexts ]
 dodona_close_failed_context() {
     jshon -Q -n object                  \

--- a/run
+++ b/run
@@ -33,27 +33,115 @@ memory_limit="$(( memory_limit * 9 / 10000 ))"
 # Record time
 start_time="$(date +"%s")"
 
+# User friendly compilation errors
+pretty_compilation_errors() {
+    # Test the name of the class.
+    wrong_class=$(echo $compile_err | grep -c "should be declared in a file named")
+    if [ "$wrong_class" -eq "1" ]; then
+        expect_class_name=$(echo $compile_err | egrep -o "^\w+.java" | sed "s/.java//g")
+        student_class_name=$(echo $compile_err | egrep -o "public class \w+" | sed "s/public class //g")
+        echo "De ingediende klasse heeft een foute naam. De klasse hoort als naam \"$expect_class_name\" te hebben, jouw klasse heeft als naam \"$student_class_name\"."
+    fi
+}
+
+# Compilation parsing
+compilation_error_count() {
+    echo "$1" | egrep -o "[0-9]+ errors?$" | sed "s/[^0-9]//g"
+}
+
+compilation_warning_count() {
+    echo "$1" | egrep -o "[0-9]+ warnings?$" | sed "s/[^0-9]//g"
+}
+
 # Compilation json
-compilation_error() {
-    jshon -Q -n object                                          \
-        -n false -i 'accepted'                                  \
-        -s 'compilation error' -i 'status'                      \
-        -s "$1" -i 'description'                                \
-        -n array                                                \
-            -n object                                           \
-                -s 'Compiler' -i 'description'                  \
-                -n array                                        \
-                    -n object                                   \
-                        -n false -i 'accepted'                  \
-                        -n array                                \
-                            -n object                           \
-                                -s 'code' -i 'format'           \
-                                -s "$(cat $2)" -i 'description' \
-                            -i 0                                \
-                        -i 'messages'                           \
-                    -i 0                                        \
-                -i 'groups'                                     \
-            -i 0                                                \
+compilation_error_in_submission() {
+    compile_err=$(cat $1)
+
+    # Get the amount of errors/warnings as a number.
+    compile_err_count=$(compilation_error_count "$compile_err")
+    compile_warn_count=$(compilation_warning_count "$compile_err")
+
+    # Get the pretty feedback.
+    # TODO: Maybe create a new message for every parsed item instead of simply
+    # TODO: concatenating everything in 1 message.
+    compile_err_pretty=$(pretty_compilation_errors "$compile_err")
+
+    # Strip the amount of errors/warnings since we're already displaying that
+    # somewhere else.
+    compile_err=$(echo "$compile_err" | sed "s/[0-9]\+ \(error\|warning\)s\?$//g")
+
+    if [ "$compile_err_count" -eq "1" ]; then
+        compile_err_word="fout"
+    else
+        compile_err_word="fouten"
+    fi
+
+    if [ "$compile_warn_count" -eq "1" ]; then
+        compile_warn_word="waarschuwing"
+    else
+        compile_warn_word="waarschuwingen"
+    fi
+
+    compile_msg="Je oplossing kon niet worden gecompileerd, de compiler rapporteerde $compile_err_count $compile_err_word en $compile_warn_count $compile_warn_word:"
+
+    jshon -Q -n object                                                    \
+        -n false -i 'accepted'                                            \
+        -s 'compilation error' -i 'status'                                \
+        -s "$compile_err_count $compile_err_word" -i 'description'        \
+        -n array                                                          \
+            -n object                                                     \
+                -s 'Compiler' -i 'description'                            \
+                -n array                                                  \
+                    -n object                                             \
+                        -n false -i 'accepted'                            \
+                        -n array                                          \
+                            -n object                                     \
+                                -s 'code' -i 'format'                     \
+                                -s "$compile_err" -i 'description'        \
+                            -i 0                                          \
+                            -n object                                     \
+                                -s 'code' -i 'format'                     \
+                                -s "$compile_err_pretty" -i 'description' \
+                            -i 0                                          \
+                            -n object                                     \
+                                -s 'plain' -i 'format'                    \
+                                -s "$compile_msg" -i 'description'        \
+                            -i 0                                          \
+                        -i 'messages'                                     \
+                    -i 0                                                  \
+                -i 'groups'                                               \
+            -i 0                                                          \
+        -i 'groups'
+}
+
+compilation_error_in_tests() {
+    compile_err=$(cat $1)
+    description="De tests van deze opgave bevatten een fout, contacteer de lesgever."
+
+    jshon -Q -n object                                             \
+        -n false -i 'accepted'                                     \
+        -s 'compilation error' -i 'status'                         \
+        -s "in tests" -i 'description'                             \
+        -n array                                                   \
+            -n object                                              \
+                -s 'Compiler' -i 'description'                     \
+                -n array                                           \
+                    -n object                                      \
+                        -n false -i 'accepted'                     \
+                        -n array                                   \
+                            -n object                              \
+                                -s 'code' -i 'format'              \
+                                -s 'staff' -i 'permission'         \
+                                -s "$compile_err" -i 'description' \
+                            -i 0                                   \
+                            -n object                              \
+                                -s 'plain' -i 'format'             \
+                                -s "$description" -i 'description' \
+                            -i 0                                   \
+                        -i 'messages'                              \
+                    -i 0                                           \
+                -i 'groups'                                        \
+            -i 0                                                   \
         -i 'groups'
 }
 
@@ -81,7 +169,7 @@ debug compiled judge
 
 # Compiling the workdir given code
 if ! find . -name '*.java' | xargs --no-run-if-empty javac -cp ".:${worklibs}:${testlibs}" -d . -sourcepath . > "$compilation" 2>&1; then
-    compilation_error "in workdir" <(sed 's_.*/\([^/]*.java\)_\1_' "$compilation")
+    compilation_error_in_tests <(sed 's_.*/\([^/]*.java\)_\1_' "$compilation")
     exit 0
 fi
 
@@ -92,7 +180,7 @@ cat "$(jshon -e 'source' -u < "$config")" > "$filename"
 
 # Compiling the user code
 if ! javac -cp ".:${worklibs}" -Xlint:all "$filename" > "$compilation" 2>&1; then
-    compilation_error "in submitted code" "$compilation" \
+    compilation_error_in_submission "$compilation" \
     | if grep -q '^package' "$filename"; then
         add_compilation_description "Are you sure the submitted class is in the default package?"
       else
@@ -105,7 +193,7 @@ debug compiled user code
 
 # Compiling the tests
 if ! find "$resources" -name '*.java' | xargs javac -cp ".:${resources}:${worklibs}:${testlibs}:judge.jar" -d . -sourcepath "$resources" > "$compilation" 2>&1; then
-    compilation_error "in tests" <(sed 's_.*/\([^/]*.java\)_\1_' "$compilation")
+    compilation_error_in_tests <(sed 's_.*/\([^/]*.java\)_\1_' "$compilation")
     exit 0
 fi
 

--- a/run
+++ b/run
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-debug() { echo -n "$@" >&2; date >&2; }
+debug() { echo -n "$@ - " >&2; date >&2; }
 debug start
 
 set -o pipefail -e
@@ -10,7 +10,7 @@ config="$(mktemp)"      # configuration
 result="$(mktemp)"      # result json
 compilation="$(mktemp)" # output of compilation
 execution="$(mktemp)"   # output of execution
-mkdir "/tmp/build"  # compilation directory
+mkdir "/tmp/build"      # compilation directory
 
 trap "rm -rf '$config' '$result' '$compilation' '$execution' '/tmp/build'" EXIT
 
@@ -30,31 +30,58 @@ time_limit="$(( time_limit - 10 ))"
 memory_limit="$(jshon -e 'memory_limit' -u < "$config")"
 memory_limit="$(( memory_limit * 9 / 10000 ))"
 
-# Record time
-start_time="$(date +"%s")"
+############################## [ Helper functions ] ############################
+# Import json helper functions.
+source $judge/dodona-json
 
-# User friendly compilation errors
-pretty_compilation_errors() {
-    # Test the name of the class.
-    wrong_class=$(echo $compile_err | grep -c "should be declared in a file named")
-    if [ "$wrong_class" -eq "1" ]; then
-        expect_class_name=$(echo $compile_err | egrep -o "^\w+.java" | sed "s/.java//g")
-        student_class_name=$(echo $compile_err | egrep -o "public class \w+" | sed "s/public class //g")
-        echo "De ingediende klasse heeft een foute naam. De klasse hoort als naam \"$expect_class_name\" te hebben, jouw klasse heeft als naam \"$student_class_name\"."
-    fi
-}
-
-# Compilation parsing
 compilation_error_count() {
-    echo "$1" | egrep -o "[0-9]+ errors?$" | sed "s/[^0-9]//g"
+    echo "$1" | egrep -o "[0-9]+ errors?$" | sed "s/[^0-9]//g" || echo "0"
 }
 
 compilation_warning_count() {
-    echo "$1" | egrep -o "[0-9]+ warnings?$" | sed "s/[^0-9]//g"
+    echo "$1" | egrep -o "[0-9]+ warnings?$" | sed "s/[^0-9]//g" || echo "0"
 }
 
-# Compilation json
+parse_compilation_error() {
+    dodona_start_context
+    dodona_start_testcase_code_message "$1"
+    dodona_close_failed_testcase
+    dodona_close_failed_context
+}
+
+parse_compilation_errors() {
+    # arg1 raw compilation output
+
+    # Processes the compilation errors, store them in an array, after which the
+    # invidual errors/warnings are processed.
+    compile_errs=()
+    compile_err=""
+    while IFS="\n" read -r line; do
+        new_case=$(echo "$line" | egrep -c "^$filename:[0-9]+:" || true)
+
+        if [[ "$new_case" == "0" || $compile_err == "" ]]; then
+            compile_err+="$line\n"
+            continue
+        fi
+
+        compile_errs+=("$compile_err")
+        compile_err="$line\n"
+    done <<< "$1"
+
+    # Last error/warning will end with "x errors/y warnings; remove this part."
+    compile_err=$(echo "$compile_err" | sed "s/[0-9]\+ warnings\?//g")
+    compile_err=$(echo "$compile_err" | sed "s/[0-9]\+ errors\?//g")
+    compile_errs+=("$compile_err")
+
+    # The errors and warnings could not be processed in the previous while
+    # loop due to problems with jshon/stdin and read.
+    for i in "${compile_errs[@]}"; do
+        parse_compilation_error "$i"
+    done
+}
+
 compilation_error_in_submission() {
+<<<<<<< HEAD
     compile_err=$(cat $1)
 
     # Get the amount of errors/warnings as a number.
@@ -144,17 +171,57 @@ compilation_error_in_tests() {
             -i 0                                                   \
         -i 'groups'
 }
+=======
+    compile_log=$(cat $1)
 
-add_compilation_description() {
-    jshon -Q                                 \
-        -e 'groups' -e 0                     \
-            -e 'groups' -e 0                 \
-                -n object                    \
-                    -s 'plain' -i 'format'    \
-                    -s "$1" -i 'description' \
-                -i 'description'             \
-        -p -p -p -p
+    # Parse the amount of compilation errors and warnings.
+    compile_err_count=$(compilation_error_count "$compile_log")
+    compile_warn_count=$(compilation_warning_count "$compile_log")
+    compile_errwarn_sum="$((compile_err_count + compile_warn_count))"
+
+    # Get the correct noun.
+    [[ "$compile_err_count" == "1" ]] && compile_err_noun="fout" || compile_err_noun="fouten"
+    [[ "$compile_warn_count" == "1" ]] && compile_warn_noun="waarschuwing" || compile_warn_noun="waarschuwingen"
+
+    dodona_start_judgement
+    dodona_start_tab "Compiler"
+    dodona_append_plain_message "Je code kon niet worden gecompileerd en bijgevolg niet worden uitgevoerd. De compiler rapporteerde $compile_err_count $compile_err_noun en $compile_warn_count $compile_warn_noun."
+
+    parse_compilation_errors "$compile_log"
+
+    dodona_close_tab $compile_errwarn_sum
+    dodona_close_judgement_compilation_error "$compile_err_count $compile_err_noun"
 }
+
+compilation_error_in_tests() {
+    compile_log=$(cat $1)
+
+    # Parse the amount of compilation errors and warnings.
+    compile_err_count=$(compilation_error_count "$compile_log")
+    compile_warn_count=$(compilation_warning_count "$compile_log")
+    compile_errwarn_sum="$((compile_err_count + compile_warn_count))"
+
+    # Get the correct noun.
+    [[ "$compile_err_count" == "1" ]] && compile_err_noun="fout" || compile_err_noun="fouten"
+    [[ "$compile_warn_count" == "1" ]] && compile_warn_noun="waarschuwing" || compile_warn_noun="waarschuwingen"
+
+    # dodona_start_judgement
+    # dodona_start_tab "Compiler"
+    # dodona_append_plain_message "Je code kon niet worden gecompileerd en bijgevolg niet worden uitgevoerd. \
+    # De compiler rapporteerde $compile_err_count $compile_err_noun en $compile_warn_count $compile_warn_noun."
+
+    parse_compilation_errors "$compile_log"
+>>>>>>> 938ae14... Implement partial output scheme.
+
+    # dodona_close_tab $compile_errwarn_sum
+    # dodona_close_judgement_compilation_error 'a'
+}
+
+
+################################# [ Start run ] ################################
+
+# Record time
+start_time="$(date +"%s")"
 
 debug after init
 
@@ -180,12 +247,7 @@ cat "$(jshon -e 'source' -u < "$config")" > "$filename"
 
 # Compiling the user code
 if ! javac -cp ".:${worklibs}" -Xlint:all "$filename" > "$compilation" 2>&1; then
-    compilation_error_in_submission "$compilation" \
-    | if grep -q '^package' "$filename"; then
-        add_compilation_description "Are you sure the submitted class is in the default package?"
-      else
-        cat
-    fi
+    compilation_error_in_submission "$compilation"
     exit 0
 fi
 

--- a/run
+++ b/run
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-debug() { echo -n "$@ - " >&2; date >&2; }
+debug() { echo -n "$@" " - " >&2; date >&2; }
 debug start
 
 set -o pipefail -e
@@ -35,79 +35,130 @@ memory_limit="$(( memory_limit * 9 / 10000 ))"
 source $judge/dodona-json
 
 compilation_error_count() {
-    echo "$1" | egrep -o "[0-9]+ errors?$" | sed "s/[^0-9]//g" || echo "0"
+    tail -n2 | sed -n 's/^\([0-9]\+\) errors\?$/\1/p'
 }
 
 compilation_warning_count() {
-    echo "$1" | egrep -o "[0-9]+ warnings?$" | sed "s/[^0-9]//g" || echo "0"
+    tail -n2 | sed -n 's/^\([0-9]\+\) warnings\?$/\1/p'
 }
 
 explain_compilation_error() {
-    echo ""
+    case "$1" in
+        *"should be declared in a file named"*)
+            # Wrong class name.
+            expected_class_name="${filename%.java}"
+            echo "De naam van je klasse hoort \"$expected_class_name\" te zijn."
+            ;;
+        *"cannot find symbol"*)
+            # Cannot find symbol - forgotten import.
+            class_name=$(echo "$1" | grep -o "symbol:\s*class \S\+" | sed "s/.*class \(\S\+\)\\\n/\1/" || true)
+            [ -z "$class_name" ] || echo "Je probeert een onbekende klasse \`$class_name\` te gebruiken. Mogelijks ben je de noodzakelijke \`import\` vergeten."
+            ;;
+        *"assign a value to final variable"*)
+            # Assignment to final variable.
+            variable_name=$(echo "$1" | grep -o "final variable \S\+" | sed "s/final variable //" | sed "s/\\\n//")
+            echo "Variabelen die als \`final\` zijn gedeclareerd, kunnen niet meer worden aangepast eens ze een waarde hebben. Verwijder het \`final\` keyword bij de variabele \"$variable_name\" om dit op te lossen."
+            ;;
+    esac
 }
 
-parse_compilation_error() {
+explain_compilation_warning() {
+    case "$1" in
+        *"found raw type"*)
+            echo "Het is aangeraden een type mee te geven aan generieke klassen."
+            ;;
+    esac
+}
+
+parse_compilation_error_staff() {
+    # arg1: 1 compiler log
+
     dodona_start_context
 
-    # Print the compilation message.
-    dodona_start_testcase_code_message "$1"
+    # Start the case.
+    dodona_start_testcase_markdown_message "Compilatiefout"
 
-    # Try to explain this compilation message, add it to the testcase if found.
-    explanation=$(explain_compilation_error "$1")
-    [[ "$explanation" == "" ]] || dodona_append_plain_message "$explanation"
+    # Append the compilation log, only visible for staff.
+    dodona_append_code_message_staff "$1"
 
-    # Get the code annotation information and annotate the code.
+    dodona_close_failed_testcase
+    dodona_close_failed_context
+}
+
+parse_compilation_error_student() {
+    # arg1: 1 compiler log
+    dodona_start_context
+
+    # Determine the kind of compilation message.
+    log_kind=$(echo "$1" | grep -o "^$filename:[0-9]\+: warning:" | grep -o "warning" || echo 'error')
+
+    # Try to explain the compilation message.
+    if [ "$log_kind" == 'error' ]; then
+        explanation=$(explain_compilation_error "$1")
+    else
+        explanation=$(explain_compilation_warning "$1")
+    fi
+
+    # Start the case, add the explanation message if it exists.
+    [ "$log_kind" == 'error' ] && testcase_msg="Compilatiefout" || testcase_msg="Compilatiewaarschuwing"
+    [ -z "$explanation" ] || testcase_msg+=": $explanation"
+    dodona_start_testcase_markdown_message "$testcase_msg"
+
+    # Append the compilation output.
+    dodona_append_code_message "$1"
+
+    # Get the code annotation information.
     annotation_column=$(echo "$1" | grep -o "\s*\^" | wc -c)
     annotation_column=$((annotation_column - 2))
-    annotation_row=$(echo "$1" | sed "s/^$filename:\([0-9]\+\):.*/\1/g")
+    annotation_row=$(echo "$1" | grep -o "^$filename:[0-9]\+:" | sed "s/^$filename:\([0-9]\+\):/\1/")
     annotation_row=$((annotation_row - 1))
-    annotation_is_error=$(echo "$1" | grep -c "^$filename:[0-9]\+: error" || true)
 
-    if [[ "$explanation" == "" ]]; then
-        annotation_text=$(echo -e "$1" | sed "s/.*: error://" | sed "s/.*: warning://" | head -n 1)
+    if [ -z "$explanation" ]; then
+        # Insert the first line of the compilation log.
+        annotation_text=$(echo "$1" | sed "s/.*: error://" | sed "s/.*: warning://" | head -n 1)
     else
-        annotation_text="$explanation"
+        # Strip the ` from markdown explanations.
+        annotation_text=$(echo "$explanation" | tr -d '\`')
     fi
 
-    if [[ "$annotation_is_error" == "1" ]]; then
-        dodona_annotate_code_error "$annotation_row" "$annotation_column" "$annotation_text"
-    else
-        dodona_annotate_code_warning "$annotation_row" "$annotation_column" "$annotation_text"
-    fi
+    # Annotate the code accordingly.
+    dodona_annotate_code "$log_kind" "$annotation_row" "$annotation_column" "$annotation_text"
 
     dodona_close_failed_testcase
     dodona_close_failed_context
 }
 
 parse_compilation_errors() {
-    # arg1 raw compilation output
+    # arg1: permission
+    # reads log from stdin
 
-    # Processes the compilation errors, store them in an array, after which the
-    # invidual errors/warnings are processed.
-    compile_errs=()
+    # Loop over the compile log and process each message individually.
     compile_err=""
-    while IFS="\n" read -r line; do
-        new_case=$(echo "$line" | egrep -c "^$filename:[0-9]+:" || true)
-
-        if [[ "$new_case" == "0" || $compile_err == "" ]]; then
-            compile_err+="$line\n"
-            continue
+    while IFS= read -r line; do
+        if echo "$line" | egrep -q "^$filename:[0-9]+:"; then
+            if [ -n "$compile_err" ]; then
+                if [ "$1" = 'student' ]; then
+                    parse_compilation_error_student "$compile_err" </dev/zero
+                else
+                    parse_compilation_error_staff "$compile_err" </dev/zero
+                fi
+            fi
+            compile_err="$line"
+        else
+            compile_err="$(printf '%s\n%s' "$compile_err" "$line")"
         fi
-
-        compile_errs+=("$compile_err")
-        compile_err="$line\n"
-    done <<< "$1"
+    done
 
     # Last error/warning will end with "x errors/y warnings; remove this part."
     compile_err=$(echo "$compile_err" | sed "s/[0-9]\+ warnings\?//g")
     compile_err=$(echo "$compile_err" | sed "s/[0-9]\+ errors\?//g")
-    compile_errs+=("$compile_err")
 
-    # The errors and warnings could not be processed in the previous while
-    # loop due to problems with jshon/stdin and read.
-    for i in "${compile_errs[@]}"; do
-        parse_compilation_error "$i"
-    done
+    # Process the last error/warning.
+    if [ "$1" == 'student' ]; then
+        parse_compilation_error_student "$compile_err" </dev/zero
+    else
+        parse_compilation_error_staff "$compile_err" </dev/zero
+    fi
 }
 
 compilation_error_in_submission() {
@@ -205,46 +256,44 @@ compilation_error_in_tests() {
     compile_log=$(cat $1)
 
     # Parse the amount of compilation errors and warnings.
-    compile_err_count=$(compilation_error_count "$compile_log")
-    compile_warn_count=$(compilation_warning_count "$compile_log")
+    compile_err_count=$(compilation_error_count < "$1")
+    compile_warn_count=$(compilation_warning_count < "$1")
     compile_errwarn_sum="$((compile_err_count + compile_warn_count))"
 
     # Get the correct noun.
-    [[ "$compile_err_count" == "1" ]] && compile_err_noun="fout" || compile_err_noun="fouten"
-    [[ "$compile_warn_count" == "1" ]] && compile_warn_noun="waarschuwing" || compile_warn_noun="waarschuwingen"
+    [ "$compile_err_count" == "1" ] && compile_err_noun="fout" || compile_err_noun="fouten"
+    [ "$compile_warn_count" == "1" ] && compile_warn_noun="waarschuwing" || compile_warn_noun="waarschuwingen"
+
+    # Build the compilation message.
+    compile_message=""
+    [ "$compile_err_count" == "" ] || compile_message="$compile_err_count $compile_err_noun"
+    [ "$compile_err_count" != "" ] && [ "$compile_warn_count" != "" ] && compile_message+=" en "
+    [ "$compile_warn_count" == "" ] || compile_message+="$compile_warn_count $compile_warn_noun"
 
     dodona_start_judgement
     dodona_start_tab "Compiler"
-    dodona_append_plain_message "Je code kon niet worden gecompileerd en bijgevolg niet worden uitgevoerd. De compiler rapporteerde $compile_err_count $compile_err_noun en $compile_warn_count $compile_warn_noun."
+    dodona_append_html_message "<div class=\"callout callout-info\">Je code kon niet worden gecompileerd en bijgevolg niet worden uitgevoerd. De compiler rapporteerde $compile_message.</div>"
 
-    parse_compilation_errors "$compile_log"
+    parse_compilation_errors 'student' <<< "$compile_log"
 
     dodona_close_tab $compile_errwarn_sum
     dodona_close_judgement_compilation_error "$compile_err_count $compile_err_noun"
 }
 
 compilation_error_in_tests() {
-    compile_log=$(cat $1)
+    dodona_start_judgement
+    dodona_start_tab "Compiler"
+    dodona_append_html_message "<div class=\"callout callout-info\">Er ging iets mis tijdens het compileren van de testen voor deze oefening. Contacteer je lesgever.</div>"
 
-    # Parse the amount of compilation errors and warnings.
-    compile_err_count=$(compilation_error_count "$compile_log")
-    compile_warn_count=$(compilation_warning_count "$compile_log")
-    compile_errwarn_sum="$((compile_err_count + compile_warn_count))"
-
-    # Get the correct noun.
-    [[ "$compile_err_count" == "1" ]] && compile_err_noun="fout" || compile_err_noun="fouten"
-    [[ "$compile_warn_count" == "1" ]] && compile_warn_noun="waarschuwing" || compile_warn_noun="waarschuwingen"
-
-    # dodona_start_judgement
-    # dodona_start_tab "Compiler"
-    # dodona_append_plain_message "Je code kon niet worden gecompileerd en bijgevolg niet worden uitgevoerd. \
-    # De compiler rapporteerde $compile_err_count $compile_err_noun en $compile_warn_count $compile_warn_noun."
-
+<<<<<<< HEAD
     parse_compilation_errors "$compile_log"
 >>>>>>> 938ae14... Implement partial output scheme.
+=======
+    parse_compilation_errors 'staff' < "$1"
+>>>>>>> 857d6fa... Implement compilation error/warning hints.
 
-    # dodona_close_tab $compile_errwarn_sum
-    # dodona_close_judgement_compilation_error 'a'
+    dodona_close_tab
+    dodona_close_judgement_compilation_error "in de testen"
 }
 
 

--- a/run
+++ b/run
@@ -42,9 +42,39 @@ compilation_warning_count() {
     echo "$1" | egrep -o "[0-9]+ warnings?$" | sed "s/[^0-9]//g" || echo "0"
 }
 
+explain_compilation_error() {
+    echo ""
+}
+
 parse_compilation_error() {
     dodona_start_context
+
+    # Print the compilation message.
     dodona_start_testcase_code_message "$1"
+
+    # Try to explain this compilation message, add it to the testcase if found.
+    explanation=$(explain_compilation_error "$1")
+    [[ "$explanation" == "" ]] || dodona_append_plain_message "$explanation"
+
+    # Get the code annotation information and annotate the code.
+    annotation_column=$(echo "$1" | grep -o "\s*\^" | wc -c)
+    annotation_column=$((annotation_column - 2))
+    annotation_row=$(echo "$1" | sed "s/^$filename:\([0-9]\+\):.*/\1/g")
+    annotation_row=$((annotation_row - 1))
+    annotation_is_error=$(echo "$1" | grep -c "^$filename:[0-9]\+: error" || true)
+
+    if [[ "$explanation" == "" ]]; then
+        annotation_text=$(echo -e "$1" | sed "s/.*: error://" | sed "s/.*: warning://" | head -n 1)
+    else
+        annotation_text="$explanation"
+    fi
+
+    if [[ "$annotation_is_error" == "1" ]]; then
+        dodona_annotate_code_error "$annotation_row" "$annotation_column" "$annotation_text"
+    else
+        dodona_annotate_code_warning "$annotation_row" "$annotation_column" "$annotation_text"
+    fi
+
     dodona_close_failed_testcase
     dodona_close_failed_context
 }

--- a/testing/test.sh
+++ b/testing/test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 path_to_exercise="$1"
 


### PR DESCRIPTION
### ~**!HOLD:  This may not be merged until https://github.ugent.be/dodona/dodona/issues/1032 is either fixed or is confirmed as not being a bug, as it imposes an authorization risk!**~

(Rewrite of #13), using the partial output scheme.

**Compilation error in submitted code:**
![compile-submission](https://github.ugent.be/storage/user/2678/files/00ffdb80-5b2b-11e9-9d16-119073ce9827)

**Compilation error in workdir/tests:**
Staff/zeus gets a compilation log (just like the student sees when there's a compilation error in their code), but this log is hidden for students as it's not their code.
![compile-tests](https://github.ugent.be/storage/user/2678/files/c185bf00-5b2b-11e9-829a-7eb13a26d11b)

**Compilation error/warning hints**
Support for more error/warning hints can be added as new errors and warnings arise by students. If no hint is found, the annotation shows the first line of the java compiler (cleaned) and the hint-message is not added in the testcase. Currently these hints are built in:
- (Error) Wrong class name
- (Warning) Use of raw types with generic classes

**Remarks:**
- Reported memory usage seems a bit high, not sure if this is actually correct since it's sometimes zero, should be verified.
- Multi-language support could be very easily added in, it's only Dutch for now.

_[Original pull request](https://github.ugent.be/dodona/judge-java/pull/15) by @thepieterdc on Wed Apr 10 2019 at 00:58._
_Merged by @ninewise on Thu Apr 25 2019 at 09:52._