### PR TITLE
Possibility to fail on compilation warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,10 @@ Please use descriptive names in `description/names/...`, these will be shown to 
 `evaluation/filename` is the name of the file the students should submit. As this is a Java judge, that's the name of the public class they should submit + `.java`.
 
 Other configuration values used by the Java judge are:
+- `evaluation/allow_compilation_warnings` - A boolean indicating whether the judge should allow compilation warnings, or should fail compilation if warnings were reported. This defaults to `true` if not set. 
 - `evaluation/time_limit` - For how long the tests can continue before a "time limit exceeded" is reported.
 - `evaluation/memory_limit` - How much memory the docker is given.
-- `evaluation/network_enabled` - Whether the code inside the docker can use the network. Disabled by default and should be enabled sparingly. While we may try to keep everything as secure as possible, a network allows for remote shells. Even if these remote shells have limited permissions, talented students might try to escalate them. 
+- `evaluation/network_enabled` - Whether the code inside the docker can use the network. Disabled by default and should be enabled sparingly. While we may try to keep everything as secure as possible, a network allows for remote shells. Even if these remote shells have limited permissions, talented students might try to escalate them.
 
 ### Where to put which code?
 
@@ -67,4 +68,3 @@ As mentioned, test files can be pure JUnit test files, including all features in
 
 - By importing `dodona.junit.TabTitle` in your exercise, you can set the title of the tab in dodona for this test (each test in TestSuite will produce on tab). Just add the `@TabTitle("Some Title")` annotation to your test class.
 - `dodona.junit.MessageWriter` is a JUnit test rule. By using `@Rule public MessageWriter out = new MessageWriter();` in your test class, you can write to `out` as if it were `System.out` (it's actually a `PrintWriter`, not a `PrintStream`, but they share most methods). Whatever you write to it in a test will be visible to the students if that test fails. Useful for e.g. printing the input matrices to a matrix multiplication exercise test, along with the expected and generated outputs.
-

--- a/run
+++ b/run
@@ -30,7 +30,8 @@ time_limit="$(( time_limit - 10 ))"
 memory_limit="$(jshon -e 'memory_limit' -u < "$config")"
 memory_limit="$(( memory_limit * 9 / 10000 ))"
 
-allow_warnings="$(jshon -e 'allow_warnings' -u < "$config")"
+# Other configuration parameters.
+allow_compilation_warnings="$(jshon -Q -e 'allow_compilation_warnings' -u < "$config" || echo 'true')"
 
 # Record time
 start_time="$(date +"%s")"
@@ -94,7 +95,7 @@ cat "$(jshon -e 'source' -u < "$config")" > "$filename"
 
 # Compiling the user code
 compile_opts="-Xlint:all"
-[ "$allow_warnings" == 'true' ] || compile_opts+=' -Werror'
+[ "$allow_compilation_warnings" == 'true' ] || compile_opts+=' -Werror'
 
 if ! javac -cp .:${worklibs} ${compile_opts} "$filename" > "$compilation" 2>&1; then
     compilation_error "in submitted code" "$compilation" \

--- a/run
+++ b/run
@@ -30,6 +30,8 @@ time_limit="$(( time_limit - 10 ))"
 memory_limit="$(jshon -e 'memory_limit' -u < "$config")"
 memory_limit="$(( memory_limit * 9 / 10000 ))"
 
+allow_warnings="$(jshon -e 'allow_warnings' -u < "$config")"
+
 # Record time
 start_time="$(date +"%s")"
 
@@ -91,7 +93,10 @@ debug compiled workdir
 cat "$(jshon -e 'source' -u < "$config")" > "$filename"
 
 # Compiling the user code
-if ! javac -cp ".:${worklibs}" -Xlint:all "$filename" > "$compilation" 2>&1; then
+compile_opts="-Xlint:all"
+[ "$allow_warnings" == 'true' ] || compile_opts+=' -Werror'
+
+if ! javac -cp .:${worklibs} ${compile_opts} "$filename" > "$compilation" 2>&1; then
     compilation_error "in submitted code" "$compilation" \
     | if grep -q '^package' "$filename"; then
         add_compilation_description "Are you sure the submitted class is in the default package?"

--- a/testing/test.sh
+++ b/testing/test.sh
@@ -6,7 +6,7 @@ path_to_exercise="$1"
     && echo 'Provide a path to an exercise as first argument.' \
     && exit 1
 
-allow_warnings="$(jshon -e 'evaluation' -e 'allow_compilation_warnings' -u < "$path_to_exercise/config.json")"
+allow_warnings="$(jshon -e 'evaluation' -e 'allow_compilation_warnings' -u < "$path_to_exercise/config.json" || echo 'true')"
 filename="$(jshon -e 'evaluation' -e 'filename' -u < "$path_to_exercise/config.json")"
 
 find "$path_to_exercise/workdir/" -mindepth 1 -maxdepth 1 | xargs cp -r -t .

--- a/testing/test.sh
+++ b/testing/test.sh
@@ -4,7 +4,7 @@ path_to_exercise="$1"
 
 [ -z "$path_to_exercise" ] \
     && echo 'Provide a path to an exercise as first argument.' \
-    && exit
+    && exit 1
 
 allow_compilation_warnings="$(jshon -Q -e 'evaluation' -e 'allow_compilation_warnings' -u < "$path_to_exercise/config.json" || echo 'true')"
 filename="$(jshon -e 'evaluation' -e 'filename' -u < "$path_to_exercise/config.json")"

--- a/testing/test.sh
+++ b/testing/test.sh
@@ -6,6 +6,7 @@ path_to_exercise="$1"
     && echo 'Provide a path to an exercise as first argument.' \
     && exit 1
 
+allow_warnings="$(jshon -e 'evaluation' -e 'allow_compilation_warnings' -u < "$path_to_exercise/config.json")"
 filename="$(jshon -e 'evaluation' -e 'filename' -u < "$path_to_exercise/config.json")"
 
 find "$path_to_exercise/workdir/" -mindepth 1 -maxdepth 1 | xargs cp -r -t .
@@ -15,6 +16,7 @@ bash "../run" <<HERE
     "resources": "$path_to_exercise/evaluation",
     "judge": "..",
     "workdir": "$(pwd)",
+    "allow_warnings": "$allow_warnings",
     "filename": "$filename",
     "time_limit": 30,
     "memory_limit": 100000000,

--- a/testing/test.sh
+++ b/testing/test.sh
@@ -4,9 +4,9 @@ path_to_exercise="$1"
 
 [ -z "$path_to_exercise" ] \
     && echo 'Provide a path to an exercise as first argument.' \
-    && exit 1
+    && exit
 
-allow_warnings="$(jshon -e 'evaluation' -e 'allow_compilation_warnings' -u < "$path_to_exercise/config.json" || echo 'true')"
+allow_compilation_warnings="$(jshon -Q -e 'evaluation' -e 'allow_compilation_warnings' -u < "$path_to_exercise/config.json" || echo 'true')"
 filename="$(jshon -e 'evaluation' -e 'filename' -u < "$path_to_exercise/config.json")"
 
 find "$path_to_exercise/workdir/" -mindepth 1 -maxdepth 1 | xargs cp -r -t .
@@ -16,7 +16,7 @@ bash "../run" <<HERE
     "resources": "$path_to_exercise/evaluation",
     "judge": "..",
     "workdir": "$(pwd)",
-    "allow_warnings": "$allow_warnings",
+    "allow_compilation_warnings": "$allow_compilation_warnings",
     "filename": "$filename",
     "time_limit": 30,
     "memory_limit": 100000000,


### PR DESCRIPTION
Fixes #5 .

The `allow_compilation_warnings` flag defaults to `true` when not set.

**exercise/config.json**
```
"evaluation": {
  "allow_compilation_warnings": false,
  "filename": "ClassName.java",
  "memory_limit": 200000000,
  "time_limit": 75
}
```

**Known issues:**
- The compiler generates an extra error if this flag is enabled, maybe this should be stripped out somewhere?
```
    error: warnings found and -Werror specified
    1 error
    1 warning
```

_[Original pull request](https://github.ugent.be/dodona/judge-java/pull/16) by @thepieterdc on Thu Apr 11 2019 at 17:22._
_Merged by @ninewise on Fri Apr 12 2019 at 13:39._